### PR TITLE
fix(src/index.js): Filter asset files by JS files only and update plugin to webpack v4

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-class WebpackBundlePlugin {
+class BundleScriptTagPlugin {
   constructor (options) {
     this.opts = Object.assign({
       prefix: 'bundle',
@@ -29,10 +29,12 @@ class WebpackBundlePlugin {
     const appDir = fs.realpathSync(process.cwd());
     const outputDir = path.resolve(appDir, output);
 
-    compiler.plugin('after-emit',(compilation) => {
-      const { assets } = compilation.getStats().toJson();
+    const bundleScript = (stats) => {
+      const { assets } = stats.toJson();
 
-      assets.forEach((asset) => {
+      const jsFiles = assets.filter(({ name }) => name.match(/\.js?$/));
+
+      jsFiles.forEach((asset) => {
         const {
           name,
           chunkNames
@@ -50,8 +52,15 @@ class WebpackBundlePlugin {
           }
         });
       });
-    });
+    };
+
+    // Run
+    if (compiler.hooks) {
+      compiler.hooks.done.tap('BundleScriptTagPlugin', bundleScript);
+    } else {
+      compiler.plugin('done', bundleScript);
+    }
   }
 }
 
-export default WebpackBundlePlugin;
+export default BundleScriptTagPlugin;


### PR DESCRIPTION
### What does this PR do?

* Only applies the plugin to JavaScript files to avoid matching undesirable files such '.js.map’.
* Update plugin compatibility to use hooks from [Webpack v4’s plugin API](https://webpack.js.org/api/compiler-hooks/).

### Context

Noticed that the plugin would write the path to the `.js.map` in the bundle script.
Also to remove the deprecation warnings when using plugin with Webpack v4, we favour `compiler.hooks` over `compiler.plugin`.