### PR TITLE
fix(src/index.js): Update plugin event for webpack v3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ class BundleScriptTagPlugin {
     const bundleScript = (stats) => {
       const { assets } = stats.toJson();
 
-      const jsFiles = assets.filter(({ name }) => name.match(/\.js?$/));
+      const jsFiles = assets.filter(({ name }) => name.match(/\.js$/));
 
       jsFiles.forEach((asset) => {
         const {
@@ -58,7 +58,7 @@ class BundleScriptTagPlugin {
     if (compiler.hooks) {
       compiler.hooks.done.tap('BundleScriptTagPlugin', bundleScript);
     } else {
-      compiler.plugin('done', bundleScript);
+      compiler.plugin('done', stats => bundleScript(stats));
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

* Fixes the regex for filtering JS files.
* Fixes a bug where compatibility with webpack v3 was broken

By changing the event to `after-emit` and passing through the stats to the bundleScript function, it's now fixed.