### PR TITLE
fix(src/index.js): Revert event to after-emit for webpack V3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ class BundleScriptTagPlugin {
     if (compiler.hooks) {
       compiler.hooks.done.tap('BundleScriptTagPlugin', bundleScript);
     } else {
-      compiler.plugin('done', stats => bundleScript(stats));
+      compiler.plugin('after-emit', compilation => bundleScript(compilation.getStats()));
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

* Reverts the event for webpack V3 to `after-emit`.